### PR TITLE
Use Lowercase Key on Location Model

### DIFF
--- a/src/Model/Location.php
+++ b/src/Model/Location.php
@@ -12,8 +12,8 @@ class Location
     protected $ch;
     protected $locode;
     protected $name;
-    protected $nameWoDiacritics;
-    protected $subDiv;
+    protected $namewodiacritics;
+    protected $subdiv;
     protected $function;
     protected $status;
     protected $date;
@@ -29,6 +29,7 @@ class Location
     public function __construct(array $data)
     {
         foreach ($data as $key => $value) {
+            $key = strtolower($key);
             $this->$key = $value;
         }
     }
@@ -62,7 +63,7 @@ class Location
      */
     public function getNameWoDiacritics()
     {
-        return $this->nameWoDiacritics;
+        return $this->namewodiacritics;
     }
 
     /**
@@ -70,7 +71,7 @@ class Location
      */
     public function getSubDiv()
     {
-        return $this->subDiv;
+        return $this->subdiv;
     }
 
     /**

--- a/tests/Model/LocationTest.php
+++ b/tests/Model/LocationTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace UN\Locode\Tests\Model;
+
+use PHPUnit\Framework\TestCase;
+use UN\Locode\Model\Location;
+
+/**
+ * Class LocationTest
+ * @package UN\Locode\Model
+ * @description Location Model Tests
+ */
+class LocationTest extends TestCase
+{
+    public function locationDataProvider()
+    {
+        return [
+            'array with lowercase key' => [
+                [
+                    'ch' => '',
+                    'locode'=> 'EE AAR',
+                    'name'=> 'Aaravete',
+                    'namewodiacritics'=> 'Aaravete',
+                    'subdiv'=> '52',
+                    'function'=> '--3-----',
+                    'status'=> 'RL',
+                    'date'=> '1301',
+                    'iata'=> '',
+                    'coordinates'=> '5908N 02545E',
+                    'remarks'=> '',
+                ]
+            ],
+            'array with camelcase key' => [
+                [
+                    'ch' => '',
+                    'locode'=> 'EE AAR',
+                    'name'=> 'Aaravete',
+                    'nameWoDiacritics'=> 'Aaravete',
+                    'subDiv'=> '52',
+                    'function'=> '--3-----',
+                    'status'=> 'RL',
+                    'date'=> '1301',
+                    'IATA'=> '',
+                    'coordinates'=> '5908N 02545E',
+                    'remarks'=> '',
+                ]
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider locationDataProvider
+     * @covers {className}::{origMethodName}
+     */
+    public function testLocationModel(array $data)
+    {
+        $location = new Location($data);
+
+        $this->assertEquals('', $location->getCh());
+        $this->assertEquals('EE AAR', $location->getLocode());
+        $this->assertEquals('Aaravete', $location->getName());
+        $this->assertEquals('Aaravete', $location->getNameWoDiacritics());
+        $this->assertEquals('52', $location->getSubDiv());
+        $this->assertEquals('--3-----', $location->getFunction());
+        $this->assertEquals('RL', $location->getStatus());
+        $this->assertEquals('1301', $location->getDate());
+        $this->assertEquals('', $location->getIata());
+        $this->assertEquals('5908N 02545E', $location->getCoordinates());
+        $this->assertEquals('', $location->getRemarks());
+        $this->assertEquals('AAR', $location->getCode());
+        $this->assertEquals('EE', $location->getCountry());
+    }
+}


### PR DESCRIPTION
The YAML data uses a lowercase key, and the `Location` model maps them as camelcase.

This PR fixes the issue by making all keys lowercase.